### PR TITLE
fix(get_logs): guard optional response attrs with `in` check

### DIFF
--- a/datadog_mcp/utils/datadog_client.py
+++ b/datadog_mcp/utils/datadog_client.py
@@ -187,9 +187,9 @@ async def fetch_logs(
             
             # Convert to dict format for backward compatibility
             result = {
-                "data": [log.to_dict() for log in response.data] if response.data else [],
-                "meta": response.meta.to_dict() if response.meta else {},
-                "links": response.links.to_dict() if response.links else {},
+                "data": [log.to_dict() for log in response.data] if "data" in response else [],
+                "meta": response.meta.to_dict() if "meta" in response else {},
+                "links": response.links.to_dict() if "links" in response else {},
             }
             
             return result


### PR DESCRIPTION
## Summary

Every `get_logs` call against this MCP currently fails with:

```
LogsListResponse has no attribute 'links' at ['received_data']['links']
```

`LogsListResponse.links` is only populated for paginated responses. When the field is absent from the API payload, the Datadog SDK's `ModelNormal.__getitem__` raises `ApiAttributeError` (a subclass of `AttributeError`) on attribute access — so the existing truthiness guard (`if response.links`) never runs. The lookup itself throws, the exception propagates out of `fetch_logs`, and the MCP tool returns an error to the model for every non-paginated query.

## Fix

Switch from `if response.links` to `if "links" in response`, which uses `ModelNormal.__contains__` and safely returns `False` when the key is absent from the data store. Apply the same guard to `data` and `meta` for consistency — those are typically always populated, but the same crash mode would apply if the API ever omitted them.

```diff
-                "data": [log.to_dict() for log in response.data] if response.data else [],
-                "meta": response.meta.to_dict() if response.meta else {},
-                "links": response.links.to_dict() if response.links else {},
+                "data": [log.to_dict() for log in response.data] if "data" in response else [],
+                "meta": response.meta.to_dict() if "meta" in response else {},
+                "links": response.links.to_dict() if "links" in response else {},
```

## Test plan
- [x] Reproduced the failure: any `get_logs` call against a query that doesn't trigger pagination returns the `ApiAttributeError`.
- [x] Verified locally that patching the line restores normal log retrieval against a real Datadog account.