### PR TITLE
fix: guard response.links against ApiAttributeError on unset SDK fields

### DIFF
--- a/datadog_mcp/utils/datadog_client.py
+++ b/datadog_mcp/utils/datadog_client.py
@@ -189,7 +189,7 @@ async def fetch_logs(
             result = {
                 "data": [log.to_dict() for log in response.data] if response.data else [],
                 "meta": response.meta.to_dict() if response.meta else {},
-                "links": response.links.to_dict() if response.links else {},
+                "links": response.links.to_dict() if getattr(response, "links", None) else {},
             }
             
             return result


### PR DESCRIPTION
## Problem

`mcp__datadog__get_logs` (and the underlying `fetch_logs()` call) intermittently fails with:

```
Error: LogsListResponse has no attribute 'links' at ['['received_data']']['links']
```

The Datadog Python SDK raises `ApiAttributeError` (subclass of `AttributeError`) when accessing unset optional response fields. The current code at `datadog_mcp/utils/datadog_client.py:192` does:

```python
"links": response.links.to_dict() if response.links else {},
```

The `if response.links` lookup itself triggers the SDK's `__getattr__`, which raises before the truthiness check can complete. So the guard fails to guard.

## Reproduction

We've reliably observed the bug on:
- **Zero-result queries** — when the Datadog Logs API returns no matching logs, the response object omits `.links`.
- **Structured-filter queries** using `:` filters (`service:`, `status:`) and `@` attribute prefixes (`@conversationId:`) — these disproportionately trigger the failure.

Pure free-text searches and queries that return logs typically succeed; the bug surfaces on the "negative" or filter-heavy paths.

## Fix

One-line change: `getattr(response, "links", None)` short-circuits before the SDK's `__getattr__` raises. Falsy values (None / missing attr) fall through to `{}`, preserving the existing API contract for callers.

```diff
-                "links": response.links.to_dict() if response.links else {},
+                "links": response.links.to_dict() if getattr(response, "links", None) else {},
```

## Notes

- I left `response.meta` (line 191) untouched — we haven't observed the same failure on `.meta` in production usage, and I prefer minimal diffs over speculative defensiveness. Happy to extend if maintainers prefer.
- No test added: the bug is in the SDK's response shape, which is hard to mock without pinning to a specific `datadog-api-client` version's internal class. The fix is defensive enough to be reviewable on inspection.

## Reach

We've been hitting this across ~10 multi-step agent tasks over the past ~6 weeks (a derivative project running `datadog-mcp` against `datadoghq.eu`). The workaround is dropping to `scalingo logs | grep`, which works but burns budget on every fallback. This patch eliminates the workaround.

Thanks for maintaining this MCP — it's been useful otherwise.